### PR TITLE
Add ros_compatibility node to dockerfile

### DIFF
--- a/docker/Dockerfile.eloquent
+++ b/docker/Dockerfile.eloquent
@@ -41,9 +41,9 @@ RUN echo "source /carla_ws/devel/setup.bash" >> ~/.bashrc
 SHELL ["/bin/bash", "-c" , "-l"]
 
 RUN sudo apt-get update && sudo apt-get install ros-eloquent-ros-environment
-RUN rosdep install --from-paths src/carla_msgs -r -y
+RUN rosdep install --from-paths src/carla_msgs src/ros_compatibility -r -y
 RUN colcon info carla_msgs
 # .bashrc does not seem to do the source
-RUN source /opt/ros/$ROS_VERSION/setup.bash && colcon build --packages-select carla_msgs
+RUN source /opt/ros/$ROS_VERSION/setup.bash && colcon build --packages-select carla_msgs ros_compatibility
 
 CMD ["ros2", "run", "carla_ros_bridge" , "carla_ros_bridge.py"]

--- a/ros_compatibility/src/ros_compatibility/ros_compatible_node.py
+++ b/ros_compatibility/src/ros_compatibility/ros_compatible_node.py
@@ -88,7 +88,7 @@ else:
 
 def main():
     print('This is a ros1 - ros2 compatibility module.',
-          'It's not meant to be executed, but rather imported')
+          'It is not meant to be executed, but rather imported')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It builds by using the following command

```
docker build -t carla-ros2-bridge -f docker/Dockerfile.eloquent .
```